### PR TITLE
feat(session): 添加心跳保活功能并延长会话有效期

### DIFF
--- a/app.py
+++ b/app.py
@@ -70,6 +70,8 @@ except KeyError as e:
 
 app.config["SQLALCHEMY_DATABASE_URI"] = DATA
 app.config["SECRET_KEY"] = KEY
+app.config["PERMANENT_SESSION_LIFETIME"] = 60 * 60 * 24 * 30  # 每30天强制自动登录
+app.config['WTF_CSRF_TIME_LIMIT'] = 60 * 60 * 2 #会话限制两小时
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 db = SQLAlchemy(app)
 
@@ -175,6 +177,15 @@ def licenses_not_software():
     with open("LICENSES_NOT_SOFTWARE", "r", encoding="utf-8") as f:
         licenses_not_software_text = f.read()
     return Response(licenses_not_software_text, mimetype="text/plain")
+
+@app.route("/heartbeat")
+@flask_login.login_required
+def heartbeat():
+    """
+    心跳保活接口
+    用于计时器页面保持会话活跃，防止长时间计时期间会话过期
+    """
+    return "", 204  # 返回空内容和204状态码
 
 @app.route("/login")
 def login():
@@ -488,6 +499,7 @@ def timer_submit():
     name = request.form.get("name")
     value = request.form.get("value")
     repeat = request.form.get("repeat")
+
     return timer(name=name, value=value, time=time, repeat=repeat)
 
 

--- a/templates/timer.html
+++ b/templates/timer.html
@@ -69,6 +69,7 @@
         let currentTime = workTime * 60; 
         let isWorking = true;
         let timerInterval;
+        let heartbeatInterval; // 心跳保活定时器
         let audioContext; // 新增音频上下文变量
 
         // 新增：用户首次点击解锁自动播放
@@ -81,6 +82,38 @@
             document.body.removeEventListener('click', unlockAudio);
         }
         document.body.addEventListener('click', unlockAudio); // 监听首次点击
+
+        // 心跳保活函数
+        function sendHeartbeat() {
+            // 创建一个隐藏的iframe来发送心跳请求
+            const iframe = document.createElement('iframe');
+            iframe.style.display = 'none';
+            iframe.src = '/heartbeat';
+            document.body.appendChild(iframe);
+            
+            // 一段时间后移除iframe以释放资源
+            setTimeout(() => {
+                if (iframe.parentNode) {
+                    iframe.parentNode.removeChild(iframe);
+                }
+            }, 5000); // 5秒后移除
+        }
+
+        // 启动心跳保活机制，每5分钟发送一次心跳
+        function startHeartbeat() {
+            // 立即发送一次心跳
+            sendHeartbeat();
+            // 每5分钟发送一次心跳
+            heartbeatInterval = setInterval(sendHeartbeat, 5 * 60 * 1000);
+        }
+
+        // 停止心跳保活机制
+        function stopHeartbeat() {
+            if (heartbeatInterval) {
+                clearInterval(heartbeatInterval);
+                heartbeatInterval = null;
+            }
+        }
 
         // 更新时间显示（保持不变）
         function updateDisplay() {
@@ -124,6 +157,7 @@
                     }, 1000);
                 } else {
                     // 无休息时间直接提交
+                    stopHeartbeat(); // 停止心跳
                     document.getElementById('timer-form').submit();
                 }
             } else {
@@ -131,10 +165,12 @@
                 const finishAudio = new Audio("/finish_sound");
                 finishAudio.play().then(() => {
                     // 音效播放完成后提交表单
+                    stopHeartbeat(); // 停止心跳
                     document.getElementById('timer-form').submit();
                 }).catch(error => {
                     console.error('完成音效播放失败:', error);
                     // 即使播放失败，仍然提交表单
+                    stopHeartbeat(); // 停止心跳
                     document.getElementById('timer-form').submit();
                 });
             }
@@ -142,6 +178,7 @@
 
         // 启动计时器
         updateDisplay();
+        startHeartbeat(); // 启动心跳保活
         timerInterval = setInterval(() => {
             currentTime--;
             updateDisplay();


### PR DESCRIPTION
- 在 app.py 中添加心跳保活接口 (/heartbeat)
- 在 timer.html 中实现心跳保活机制，每 5 分钟发送一次心跳请求
- 设置 PERMANENT_SESSION_LIFETIME 为 30 天，延长用户登录状态保持时间
- 添加 CSRF 会话时间限制为 2 小时
测试：在开发环境下通过30分钟+6分钟测试，无csrf过期报错