### PR TITLE
feat: 用JS在前端验证表单

### DIFF
--- a/templates/add_new_reward.html
+++ b/templates/add_new_reward.html
@@ -26,6 +26,27 @@
         <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
         <link href="{{ url_for('static', filename='css.css') }}" rel="stylesheet">
         <title>添加新奖励或任务</title>
+        <script>
+            function validateRewardForm() {
+                // 获取表单元素
+                const name = document.forms["rewardForm"]["name"].value;
+                const points = document.forms["rewardForm"]["points"].value;
+                
+                // 验证奖励名称
+                if (name == null || name.trim() === "") {
+                    alert("请输入奖励名称");
+                    return false;
+                }
+                
+                // 验证积分值
+                if (points == null || points === "" || parseInt(points) <= 0) {
+                    alert("请输入有效的积分值（大于0的数字）");
+                    return false;
+                }
+                
+                return true;
+            }
+        </script>
     </head>
 
     <body>
@@ -39,7 +60,7 @@
             {% endwith %}
         </div>
         <h1>添加</h1>
-        <form action="/add_reward_submit" method="POST">
+        <form name="rewardForm" action="/add_reward_submit" method="POST" onsubmit="return validateRewardForm()">
             <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
             <div style="margin: 10px;">
                 <label>名称：</label>

--- a/templates/add_new_task.html
+++ b/templates/add_new_task.html
@@ -26,6 +26,55 @@
         <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
         <link href="{{ url_for('static', filename='css.css') }}" rel="stylesheet">
         <title>添加新奖励或任务</title>
+        <script>
+            function validateTaskForm() {
+                // 获取表单元素
+                const name = document.forms["taskForm"]["name"].value;
+                const points = document.forms["taskForm"]["points"].value;
+                const time = document.forms["taskForm"]["time"].value;
+                const importance = document.forms["taskForm"]["importance"].value;
+                const value = document.forms["taskForm"]["value"].value;
+                const urgent = document.forms["taskForm"]["urgent"].value;
+                
+                // 验证任务名称
+                if (name == null || name.trim() === "") {
+                    alert("请输入任务名称");
+                    return false;
+                }
+                
+                // 验证积分值
+                if (points == null || points === "" || parseInt(points) <= 0) {
+                    alert("请输入有效的积分值（大于0的数字）");
+                    return false;
+                }
+                
+                // 验证时间
+                if (time == null || time === "" || parseInt(time) < 0) {
+                    alert("请输入有效的时间（大于等于0的数字）");
+                    return false;
+                }
+                
+                // 验证重要性
+                if (!importance) {
+                    alert("请选择任务重要性");
+                    return false;
+                }
+                
+                // 验证价值
+                if (!value) {
+                    alert("请选择任务价值");
+                    return false;
+                }
+                
+                // 验证紧急程度
+                if (!urgent) {
+                    alert("请选择任务紧急程度");
+                    return false;
+                }
+                
+                return true;
+            }
+        </script>
     </head>
 
     <body>
@@ -39,7 +88,7 @@
             {% endwith %}
         </div>
         <h1>添加</h1>
-        <form action="/add_task_submit" method="POST">
+        <form name="taskForm" action="/add_task_submit" method="POST" onsubmit="return validateTaskForm()">
             <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
             <div style="margin: 10px;">
                 <label>名称：</label>

--- a/templates/login.html
+++ b/templates/login.html
@@ -27,6 +27,27 @@
         <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
         <link href="{{ url_for('static', filename='css.css') }}" rel="stylesheet">
         <title>用户登录</title>
+        <script>
+            function validateLoginForm() {
+                // 获取表单元素
+                const username = document.forms["loginForm"]["username"].value;
+                const password = document.forms["loginForm"]["password"].value;
+                
+                // 验证用户名
+                if (username == null || username.trim() === "") {
+                    alert("请输入用户名");
+                    return false;
+                }
+                
+                // 验证密码
+                if (password == null || password === "") {
+                    alert("请输入密码");
+                    return false;
+                }
+                
+                return true;
+            }
+        </script>
     </head>
 
     <body>
@@ -40,7 +61,7 @@
             {% endwith %}
         </div>
         <h1>登录</h1>
-        <form action="/login_submit" method="post">
+        <form name="loginForm" action="/login_submit" method="post" onsubmit="return validateLoginForm()">
             <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
             <label for="username">用户名</label>
             <input id="username" name="username" type="text">

--- a/templates/register.html
+++ b/templates/register.html
@@ -27,6 +27,33 @@
     <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
     <link href="{{ url_for('static', filename='css.css') }}" rel="stylesheet">
     <title>用户注册</title>
+    <script>
+        function validateRegisterForm() {
+            // 获取表单元素
+            const username = document.forms["registerForm"]["username"].value;
+            const password = document.forms["registerForm"]["password"].value;
+            
+            // 验证用户名
+            if (username == null || username.trim() === "") {
+                alert("请输入用户名");
+                return false;
+            }
+            
+            // 验证密码
+            if (password == null || password === "") {
+                alert("请输入密码");
+                return false;
+            }
+            
+            // 验证密码长度
+            if (password.length < 6) {
+                alert("密码长度至少为6位");
+                return false;
+            }
+            
+            return true;
+        }
+    </script>
 </head>
 
 <body>
@@ -40,7 +67,7 @@
     {% endif %}
     {% endwith %}
     <h1>注册</h1>
-    <form action="/register_submit" method="post">
+    <form name="registerForm" action="/register_submit" method="post" onsubmit="return validateRegisterForm()">
         <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
         <label for="username">用户名</label>
         <input id="username" name="username" required type="text">


### PR DESCRIPTION
- 在 add_new_reward.html、add_new_task.html、login.html 和 register.html 中添加了表单验证脚本
- 验证内容包括必填项检查、数值范围检查和密码长度检查
- 表单提交时触发验证，验证失败时弹出提示信息并阻止表单提交 
（哈哈，前端部分几乎没有人工写的部分了。不是JavaScript学不起，而是让AI写更有性价比？）